### PR TITLE
Replace User table with Admin table for admin authentication

### DIFF
--- a/config/admin_session.php
+++ b/config/admin_session.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'session.php';
 
-if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+if (!isset($_SESSION['admin_id'])) {
     header("Location: ../../Views/admin/admin_login.php");
     exit();
 }

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -9,11 +9,10 @@ CREATE TABLE PostalCode (
     PRIMARY KEY (PostalCode)
 );
 
-CREATE TABLE User (
-    UserID INT AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE Admin (
+    AdminID INT AUTO_INCREMENT PRIMARY KEY,
     Email VARCHAR(255),
-    `Password` VARCHAR(255),
-    `Role` VARCHAR(50)
+    `Password` VARCHAR(255)
 );
 
 CREATE TABLE Movie (
@@ -118,8 +117,8 @@ CREATE TABLE News (
     Content TEXT,
     DatePublished DATE,
     Category ENUM('Event', 'Announcement', 'Update') DEFAULT 'Announcement',
-    UserID INT,
-    FOREIGN KEY (UserID) REFERENCES User(UserID) ON DELETE CASCADE
+    AdminID INT,
+    FOREIGN KEY (AdminID) REFERENCES Admin(AdminID) ON DELETE CASCADE
 );
 
 CREATE TABLE Event (

--- a/sql/testdata.sql
+++ b/sql/testdata.sql
@@ -8,11 +8,6 @@ VALUES
     ('John', 'Doe', 'johndoe@example.com', 'password123', '000-1234', '5A', 'Main Street', 'Dreamland', '12345'), 
     ('Jane', 'Smith', 'janesmith@example.com', 'password456', '555-5678', '10B', 'Nowhere Street', 'Wonderland', '56789');
 
-INSERT INTO User (Email, `Password`, `Role`) 
-VALUES
-    ('admin@example.com', 'adminpass', 'admin'),
-    ('editor@example.com', 'editorpass', 'editor');
-
 INSERT INTO Movie (Title, Subtitle, Duration, Genre, ReleaseYear, Director, MovieDescription) 
 VALUES 
     ('Fast & Furious 1', 'Cars, Crime, and Culinary Curiosity', 106, 'Action, Crime', 2001, 'Rob Cohen', 'Brian’s detective work mostly involves eating his way to the top, while Dom shows everyone that racing isn’t as important as being a family man. Brian’s undercover strategy? Pretend to be a guy who loves tuna and illegal street racing. Brilliant plan.'),
@@ -87,16 +82,16 @@ VALUES
     ('Completed', 25.00, '2024-10-03', 1, 1),
     ('Pending', 30.00, '2024-10-03', 2, 2);
 
-INSERT INTO News (Title, Content, DatePublished, Category, UserID) 
+INSERT INTO Admin (Email, `Password`)
+VALUES
+    ('vitkai.nora@gmail.com', '$2y$10$kcilhapT7/oMgtsqz3xf4.K1IcvMkviTtuHE7p848QtI9/RNx8IrO');
+
+INSERT INTO News (Title, Content, DatePublished, Category, AdminID) 
 VALUES
     ('Fast X Breaks Records!', 'The latest Fast & Furious movie has shattered expectations...', '2024-10-01', 'Announcement', 1),
-    ('Upcoming Event: Torretto Tuesday!', 'Join us on Tuesdays when every guest gets a chance to win Fast & Furious memorabilia!', '2024-10-02', 'Event', 2);
+    ('Upcoming Event: Torretto Tuesday!', 'Join us on Tuesdays when every guest gets a chance to win Fast & Furious memorabilia!', '2024-10-02', 'Event', 1);
 
 INSERT INTO Event (EventName, EventDate, EventDescription, Discount, ScreeningID) 
 VALUES
     ('Torretto Tuesday', '2024-10-08', 'Special screenings of all Fast & Furious movies! Win memorabilia!', 10.00, 1),
     ('Family Friday', '2024-10-11', 'Bring the family for a 30% discount on all Fast & Furious screenings!', 30.00, 1);
-
-INSERT INTO User (Email, `Password`, `Role`)
-VALUES
-    ('vitkai.nora@gmail.com', '$2y$10$kcilhapT7/oMgtsqz3xf4.K1IcvMkviTtuHE7p848QtI9/RNx8IrO', 'admin');

--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -15,17 +15,15 @@ if (!in_array($action, $allowedActions, true)) {
 }
 
 if ($action === 'login' && $_SERVER['REQUEST_METHOD'] === 'POST') {
-    $username = sanitizeInput($_POST['username'] ?? '');
+    $email = sanitizeInput($_POST['username'] ?? '');
     $password = $_POST['password'] ?? '';
 
-    $stmt = $pdo->prepare("SELECT UserID, Password, Role FROM User WHERE Email = :email AND Role = 'admin'");
-    $stmt->execute(['email' => $username]);
-    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    $stmt = $pdo->prepare("SELECT AdminID, Password FROM Admin WHERE Email = :email");
+    $stmt->execute(['email' => $email]);
+    $admin = $stmt->fetch(PDO::FETCH_ASSOC);
 
-    if ($user && password_verify($password, $user['Password'])) {
-        $_SESSION['user_id'] = $user['UserID'];
-        $_SESSION['role'] = $user['Role'];
-
+    if ($admin && password_verify($password, $admin['Password'])) {
+        $_SESSION['admin_id'] = $admin['AdminID'];
         header("Location: ../../src/Views/admin/admin_dashboard.php");
         exit();
     } else {

--- a/src/Views/admin/admin_login.php
+++ b/src/Views/admin/admin_login.php
@@ -16,14 +16,14 @@
             <form action="../../../src/Controllers/AdminController.php?action=login" method="post" class="mb-0 mt-6 space-y-4 rounded-lg p-4 shadow-lg sm:p-6 lg:p-8 bg-zinc-800">    
                 <h2 class="text-center text-lg font-medium text-zinc-200">Sign in to your account</h2>
                 <div>
-                    <label for="username" class="sr-only">Username</label>
+                    <label for="username" class="sr-only">Email</label>
                     <div class="relative">
                         <input
                             type="text"
                             name="username"
                             id="username"
                             class="w-full rounded-lg border-zinc-600 px-5 py-3 text-sm shadow-sm bg-zinc-700 text-zinc-100 placeholder-zinc-300 focus:outline-none focus:ring-1 focus:ring-orange-600"
-                            placeholder="Username"
+                            placeholder="Email"
                             required
                         />
                     </div>
@@ -48,7 +48,7 @@
                 <p class="text-center text-red-600 mt-4">
                     Invalid email or password, please try again.
                 </p>
-            <?php endif; ?>
+                <?php endif; ?>
             </form>
         </div>
     </div>


### PR DESCRIPTION
Updated authentication to use Admin table instead of User, removed the role attribute as admins are now distinctly managed, and modified related files accordingly.