### PR TITLE
Resolve issue with globally reserved seats across screenings

### DIFF
--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -116,7 +116,6 @@ CREATE TABLE Seat (
     SeatID INT AUTO_INCREMENT PRIMARY KEY,
     RowLabel CHAR(1) NOT NULL,
     SeatNumber INT UNSIGNED NOT NULL,
-    SeatStatus ENUM('Available', 'Reserved') NOT NULL DEFAULT 'Available',
     RoomID INT NOT NULL,
     FOREIGN KEY (RoomID) REFERENCES Room(RoomID) ON DELETE CASCADE,
     UNIQUE (RowLabel, SeatNumber, RoomID)
@@ -260,28 +259,6 @@ LEFT JOIN
     MovieImage mi ON m.MovieID = mi.MovieID
 WHERE 
     s.ScreeningDate = CURDATE();
-
-DELIMITER $$
-CREATE TRIGGER trg_after_allocations_insert
-AFTER INSERT ON Allocations
-FOR EACH ROW
-BEGIN
-    UPDATE Seat 
-    SET SeatStatus = 'Reserved' 
-    WHERE SeatID = NEW.SeatID;
-END$$
-DELIMITER ;
-
-DELIMITER $$
-CREATE TRIGGER trg_after_allocations_delete
-AFTER DELETE ON Allocations
-FOR EACH ROW
-BEGIN
-    UPDATE Seat 
-    SET SeatStatus = 'Available' 
-    WHERE SeatID = OLD.SeatID;
-END$$
-DELIMITER ;
 
 DELIMITER $$
 CREATE TRIGGER trg_after_customer_update

--- a/src/Views/frontend/seat_reservation.php
+++ b/src/Views/frontend/seat_reservation.php
@@ -17,7 +17,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     $isLoggedIn = isset($_SESSION['user_id']);
-
     $seatIDsRaw = $_POST['seat_ids'] ?? [];
     $seatIDs = array_map('sanitizeInput', $seatIDsRaw);
 
@@ -54,15 +53,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     ];
 
     if (!$isLoggedIn) {
-        $guestFirstNameRaw = $_POST['guest_first_name'] ?? '';
-        $guestLastNameRaw = $_POST['guest_last_name'] ?? '';
-        $guestEmailRaw = $_POST['guest_email'] ?? '';
-        $guestPhoneRaw = $_POST['guest_phone'] ?? '';
-
-        $guestFirstName = sanitizeInput($guestFirstNameRaw);
-        $guestLastName = sanitizeInput($guestLastNameRaw);
-        $guestEmail = sanitizeInput($guestEmailRaw);
-        $guestPhone = sanitizeInput($guestPhoneRaw);
+        $guestFirstName = sanitizeInput($_POST['guest_first_name'] ?? '');
+        $guestLastName = sanitizeInput($_POST['guest_last_name'] ?? '');
+        $guestEmail = sanitizeInput($_POST['guest_email'] ?? '');
+        $guestPhone = sanitizeInput($_POST['guest_phone'] ?? '');
 
         if (empty($guestFirstName) || empty($guestLastName) || empty($guestEmail)) {
             $_SESSION['error_message'] = "Please fill in all required guest details.";
@@ -104,13 +98,9 @@ if (!isset($_GET['screening_id']) || !is_numeric($screeningId)) {
 }
 
 $screeningDetails = $screeningController->getScreeningById($screeningId);
-
-if (!$screeningDetails) {
-    die("Screening not found.");
-}
+if (!$screeningDetails) die("Screening not found.");
 
 $roomId = $screeningDetails['RoomID'];
-
 $roomSeats = $reservationController->getSeatsByRoomId($roomId);
 $reservedSeats = $reservationController->getReservedSeatsByScreeningId($screeningId);
 


### PR DESCRIPTION
Fixed the seat reservation system to ensure seats are reserved only for specific screenings. Removed the SeatStatus column and its triggers, simplifying seat availability via the Allocations table. Updated ReservationModel.php and seat_reservation.php to align with the new logic.